### PR TITLE
added cryptokeys measurement extension

### DIFF
--- a/cddl/examples/irim-cryptokey1.diag
+++ b/cddl/examples/irim-cryptokey1.diag
@@ -1,0 +1,46 @@
+/ concise-mid-tag / {
+  / tag-identity / 1 : {
+    / tag-id / 0 : "Reference for SPDM Lead Attester 4"
+  },
+  / triples / 4 : {
+    / reference-triples / 0 : [
+      / reference-triple-record / [
+        / environment-map / {
+          / ** env0 ** /
+          / comid.class / 0 : {
+            / comid.vendor / 1 : "ACME.example",
+            / comid.model / 2 : "MAX.example"
+          }
+        },
+        / measurement-map / {
+          / mval / 1 : {
+            / comid.digests / 2 : [
+              / digest / [
+              / alg: / 7, / SHA384 /
+              / val: / h'3D90B6BF003DA2D94EA5463F97FB3C53DDC51CFBA1E3E38EEF7AF071A67986595D22729131DF9FE80F5451EEF154F85E'
+              ]
+            ],
+            / corim.svn / 1 : 552(55),
+            / version-map / 0 : {
+              / comid.version / 0 : "1.3.0"
+            }
+          }
+        }
+      ]
+    ],
+    / identity-triples / 2 : [
+      / identity-triple-record / [
+        / environment-map / {
+          / ** env0 ** /
+          / comid.class / 0 : {
+            / comid.vendor / 1 : "ACME.example",
+            / comid.model / 2 : "MAX.example"
+          }
+        },
+        / crypto-key-type-choice / [
+          / agged-pkix-base64-key-type / 554("base64_key_ACME_MAX")
+        ]
+      ]
+    ]
+  }
+}

--- a/cddl/examples/irim-cryptokey1.diag
+++ b/cddl/examples/irim-cryptokey1.diag
@@ -1,12 +1,11 @@
 / concise-mid-tag / {
   / tag-identity / 1 : {
-    / tag-id / 0 : "Reference for SPDM Lead Attester 4"
+    / tag-id / 0 : "Reference CryptoKeys"
   },
   / triples / 4 : {
     / reference-triples / 0 : [
       / reference-triple-record / [
         / environment-map / {
-          / ** env0 ** /
           / comid.class / 0 : {
             / comid.vendor / 1 : "ACME.example",
             / comid.model / 2 : "MAX.example"
@@ -14,32 +13,13 @@
         },
         / measurement-map / {
           / mval / 1 : {
-            / comid.digests / 2 : [
-              / digest / [
-              / alg: / 7, / SHA384 /
-              / val: / h'3D90B6BF003DA2D94EA5463F97FB3C53DDC51CFBA1E3E38EEF7AF071A67986595D22729131DF9FE80F5451EEF154F85E'
-              ]
-            ],
-            / corim.svn / 1 : 552(55),
-            / version-map / 0 : {
-              / comid.version / 0 : "1.3.0"
-            }
+            / tee.cryptokeys / -91 : [
+              / tagged-pkix-base64-key-type / 554("base64_key_ACME_MAX"),
+              / tagged-pkix-base64-cert-type / 555("base64_cert_ACME_MAX"),
+              / tagged-pkix-base64-cert-path-type / 556("base64_cert_path_ACME_MAX")
+            ]
           }
         }
-      ]
-    ],
-    / identity-triples / 2 : [
-      / identity-triple-record / [
-        / environment-map / {
-          / ** env0 ** /
-          / comid.class / 0 : {
-            / comid.vendor / 1 : "ACME.example",
-            / comid.model / 2 : "MAX.example"
-          }
-        },
-        / crypto-key-type-choice / [
-          / agged-pkix-base64-key-type / 554("base64_key_ACME_MAX")
-        ]
       ]
     ]
   }

--- a/cddl/examples/irim-sla3.diag
+++ b/cddl/examples/irim-sla3.diag
@@ -1,11 +1,12 @@
 / concise-mid-tag / {
   / tag-identity / 1 : {
-    / tag-id / 0 : "Reference CryptoKey"
+    / tag-id / 0 : "Reference for SPDM Lead Attester 3"
   },
   / triples / 4 : {
     / reference-triples / 0 : [
       / reference-triple-record / [
         / environment-map / {
+          / ** env0 ** /
           / comid.class / 0 : {
             / comid.vendor / 1 : "ACME.example",
             / comid.model / 2 : "MAX.example"
@@ -13,13 +14,32 @@
         },
         / measurement-map / {
           / mval / 1 : {
-            / tee.cryptokeys / -91 : [
-              / tagged-pkix-base64-key-type / 554("base64_key_ACME_MAX"),
-              / tagged-pkix-base64-cert-type / 555("base64_cert_ACME_MAX"),
-              / tagged-pkix-base64-cert-path-type / 556("base64_cert_path_ACME_MAX")
-            ]
+            / comid.digests / 2 : [
+              / digest / [
+              / alg: / 7, / SHA384 /
+              / val: / h'3D90B6BF003DA2D94EA5463F97FB3C53DDC51CFBA1E3E38EEF7AF071A67986595D22729131DF9FE80F5451EEF154F85E'
+              ]
+            ],
+            / corim.svn / 1 : 552(55),
+            / version-map / 0 : {
+              / comid.version / 0 : "1.3.0"
+            }
           }
         }
+      ]
+    ],
+    / identity-triples / 2 : [
+      / identity-triple-record / [
+        / environment-map / {
+          / ** env0 ** /
+          / comid.class / 0 : {
+            / comid.vendor / 1 : "ACME.example",
+            / comid.model / 2 : "MAX.example"
+          }
+        },
+        / crypto-key-type-choice / [
+          / tagged-pkix-base64-key-type / 554("base64_key_ACME_MAX")
+        ]
       ]
     ]
   }

--- a/cddl/examples/irim-sla3.diag
+++ b/cddl/examples/irim-sla3.diag
@@ -1,12 +1,11 @@
 / concise-mid-tag / {
   / tag-identity / 1 : {
-    / tag-id / 0 : "Reference for SPDM Lead Attester 4"
+    / tag-id / 0 : "Reference CryptoKey"
   },
   / triples / 4 : {
     / reference-triples / 0 : [
       / reference-triple-record / [
         / environment-map / {
-          / ** env0 ** /
           / comid.class / 0 : {
             / comid.vendor / 1 : "ACME.example",
             / comid.model / 2 : "MAX.example"
@@ -14,32 +13,13 @@
         },
         / measurement-map / {
           / mval / 1 : {
-            / comid.digests / 2 : [
-              / digest / [
-              / alg: / 7, / SHA384 /
-              / val: / h'3D90B6BF003DA2D94EA5463F97FB3C53DDC51CFBA1E3E38EEF7AF071A67986595D22729131DF9FE80F5451EEF154F85E'
-              ]
-            ],
-            / corim.svn / 1 : 552(55),
-            / version-map / 0 : {
-              / comid.version / 0 : "1.3.0"
-            }
+            / tee.cryptokeys / -91 : [
+              / tagged-pkix-base64-key-type / 554("base64_key_ACME_MAX"),
+              / tagged-pkix-base64-cert-type / 555("base64_cert_ACME_MAX"),
+              / tagged-pkix-base64-cert-path-type / 556("base64_cert_path_ACME_MAX")
+            ]
           }
         }
-      ]
-    ],
-    / identity-triples / 2 : [
-      / identity-triple-record / [
-        / environment-map / {
-          / ** env0 ** /
-          / comid.class / 0 : {
-            / comid.vendor / 1 : "ACME.example",
-            / comid.model / 2 : "MAX.example"
-          }
-        },
-        / crypto-key-type-choice / [
-          / agged-pkix-base64-key-type / 554("base64_key_ACME_MAX")
-        ]
       ]
     ]
   }

--- a/cddl/profile-frags.mk
+++ b/cddl/profile-frags.mk
@@ -15,6 +15,7 @@ PROFILE_FRAGS += epoch-expr.cddl
 PROFILE_FRAGS += epoch-type.cddl
 PROFILE_FRAGS += tee-advisory-ids-type.cddl
 PROFILE_FRAGS += tee-attributes-type.cddl
+PROFILE_FRAGS += tee-cryptokey-type.cddl
 PROFILE_FRAGS += tee-date-type.cddl
 PROFILE_FRAGS += tee-digest-type.cddl
 PROFILE_FRAGS += tee-epoch-type.cddl

--- a/cddl/tee-cryptokey-type.cddl
+++ b/cddl/tee-cryptokey-type.cddl
@@ -1,0 +1,4 @@
+$$measurement-values-map-extension //= (
+  &(tee.cryptokeys: -91) => [ + $tee-cryptokey-type ]
+)
+$tee-cryptokey-type /= $crypto-key-type-choice

--- a/draft-cds-rats-intel-corim-profile.md
+++ b/draft-cds-rats-intel-corim-profile.md
@@ -592,6 +592,16 @@ and a tuple containing the reference and mask when used as a Reference Value.
 {::include cddl/tee-attributes-type.cddl}
 ~~~
 
+### The tee-cryptokey-type Measurement Extension {#sec-tee-cryptokey-type}
+
+The `tee.cryptokeys` extension identifies cryptographic keys associated with a Target Environment.
+If multiple `$crypto-key-type-choice` measurements are supplied, array position disambiguates each entry.
+Appraisal compares values indexed by array position.
+
+~~~ cddl
+{::include cddl/tee-cryptokey-type.cddl}
+~~~
+
 ### The tee-date-type Measurement Extension {#sec-tee-date-type}
 
 The `tee.tcbdate` extension enables the Attester or Endorser to report the TEE date attribute


### PR DESCRIPTION
Cryptokeys measurement extension describes keys that are neither identity or attestation keys. They are simply keys associated with a Target Environment.