### PR TITLE
Update tee-advisory-ids-type.cddl

### DIFF
--- a/cddl/tee-advisory-ids-type.cddl
+++ b/cddl/tee-advisory-ids-type.cddl
@@ -1,5 +1,5 @@
 $$measurement-values-map-extension //= (
   &(tee.advisory-ids: -89) => $tee-advisory-ids-type
 )
-$tee-advisory-ids-type /= ([ + tstr  ])
-$tee-advisory-ids-type /= tagged-exp-disjoint
+$tee-advisory-ids-type /= set-type
+$tee-advisory-ids-type /= tagged-exp-not-member


### PR DESCRIPTION
make use of set-type and set-type operators consistent