### PR TITLE
Cleanup tdate time and epoch

### DIFF
--- a/cddl/epoch-expr.cddl
+++ b/cddl/epoch-expr.cddl
@@ -13,3 +13,23 @@ tagged-exp-epoch-lt = #6.60010([
 tagged-exp-epoch-le = #6.60010([
     le .within epoch-operator
     grace-period: epoch-seconds-type ])
+
+tagged-exp-epoch-id-gt = #6.60010([
+    gt .within epoch-operator
+    grace-period: epoch-seconds-type
+    epoch-id: $tagged-epoch-id ])
+
+tagged-exp-epoch-id-ge = #6.60010([
+    ge .within epoch-operator
+    grace-period: epoch-seconds-type 
+    epoch-id: $tagged-epoch-id ])
+
+tagged-exp-epoch-id-lt = #6.60010([
+    lt .within epoch-operator
+    grace-period: epoch-seconds-type 
+    epoch-id: $tagged-epoch-id ])
+
+tagged-exp-epoch-id-le = #6.60010([
+    le .within epoch-operator
+    grace-period: epoch-seconds-type 
+    epoch-id: $tagged-epoch-id ])

--- a/cddl/epoch-type.cddl
+++ b/cddl/epoch-type.cddl
@@ -3,8 +3,9 @@ epoch-seconds-type = int
 epoch-expression = [ 
     epoch-operator,
     grace-period: epoch-seconds-type,
-    ? $tagged-epoch-id
+    ? epoch-id: $tagged-epoch-id
 ]
 tagged-epoch-expression = #6.60010( epoch-expression )
 $tagged-epoch-id /= tdate
+$tagged-epoch-id /= time
 $epoch-timestamp-type /= $tagged-epoch-id

--- a/cddl/examples/ice-epoch1.diag
+++ b/cddl/examples/ice-epoch1.diag
@@ -12,13 +12,15 @@
         },
         [
           / measurement-map / {
-            / mval / 1 : {
-              / epoch / -90 : 0("2023-06-09T00:00:00Z")
-            }
+            / mval / 1 : { -90 : 0("2023-06-09T00:00:00Z") } / epoch as tdate timestamp /
           },
-          {
-            / mkey / 0 : 90, / epoch /
-            / mval / 1 : { 11 : "2023-06-09T00:00:00Z" }
+          / measurement-map / {
+            / mkey / 0 : 90,
+            / mval / 1 : { 11 : "2023-06-09T00:00:00Z" }  / epoch as ~tdate timestamp /
+          },
+          / measurement-map / {
+            / mkey / 0 : "test1",
+            / mval / 1 : { -90 : 1(1742590255) } / epoch as time timestamp /
           }
         ]
       ]

--- a/cddl/examples/irim-epoch1.diag
+++ b/cddl/examples/irim-epoch1.diag
@@ -15,9 +15,25 @@
         [
           / measurement-map / {
             / mval / 1 : {
-              / epoch / -90 : 60010(
-                [ / gt / 1, / grace period seconds / 120 ]
-              )
+              / epoch / -90 : 60010([ / ge / 2, / grace sec / 120 ])
+            }
+          },
+          / measurement-map / {
+            / mkey / 0 : "test1",
+            / mval / 1 : {
+              / epoch / -90 : 60010([ / gt / 1, / grace sec / 120 ])
+            }
+          },
+          / measurement-map / {
+            / mkey / 0 : "test2",
+            / mval / 1 : {
+              / epoch / -90 : 60010([ / lt / 3, / grace sec / 140, / epoch id/ 1(1742596974) ])
+            }
+          },
+          / measurement-map / {
+            / mkey / 0 : "test3",
+            / mval / 1 : {
+              / epoch / -90 : 60010([ / le / 4, / grace sec / 3600, / epoch id / 0("2023-06-09T00:00:00Z") ])
             }
           }
         ]

--- a/cddl/examples/irim-qe-cend.diag
+++ b/cddl/examples/irim-qe-cend.diag
@@ -73,7 +73,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2023-02-15T00:00:00Z"),
+                  / tcbdate / -72 : "2023-02-15T00:00:00Z",
                   / tcbstatus / -88 : [ "UpToDate" ],
                   / tcb-eval-num / -86 : 15
                 }
@@ -99,7 +99,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2021-11-10T00:00:00Z"),
+                  / tcbdate / -72 : "2021-11-10T00:00:00Z",
                   / tcbstatus / -88 : [ "OutOfDate" ]
                 }
               }
@@ -116,7 +116,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2020-11-11T00:00:00Z"),
+                  / tcbdate / -72 : "2020-11-11T00:00:00Z",
                   / tcbstatus / -88 : [ "OutOfDate" ]
                 }
               }
@@ -133,7 +133,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2019-11-13T00:00:00Z"),
+                  / tcbdate / -72 : "2019-11-13T00:00:00Z",
                   / tcbstatus / -88 : [ "OutOfDate" ]
                 }
               }
@@ -150,7 +150,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2019-05-15T00:00:00Z"),
+                  / tcbdate / -72 : "2019-05-15T00:00:00Z",
                   / tcbstatus / -88 : [ "OutOfDate" ]
                 }
               }
@@ -167,7 +167,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2018-08-15T00:00:00Z"),
+                  / tcbdate / -72 : "2018-08-15T00:00:00Z",
                   / tcbstatus / -88 : [ "OutOfDate" ]
                 }
               }

--- a/cddl/examples/irim-s3m-sgx-appraisal.diag
+++ b/cddl/examples/irim-s3m-sgx-appraisal.diag
@@ -18,7 +18,7 @@
               { / *** measurement-map *** /
                 / mval / 1 : / measurement-values-map / {
                   / tcbstatus / -88: 60010([ / member / 6, [ "UpToDate", "SWHardeningNeeded" ] ]),
-                  / tcbdate / -72: 60010([ / ge / 2, 0("2020-07-28T00:00:00Z") ])
+                  / tcbdate / -72: 60010([ / ge / 2, "2020-07-28T00:00:00Z" ])
                 }
               }
             ]

--- a/cddl/examples/irim-seam-crs.diag
+++ b/cddl/examples/irim-seam-crs.diag
@@ -68,7 +68,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2021-06-09T00:00:00Z"),
+                  / tcbdate / -72 : "2021-06-09T00:00:00Z",
                   / tcbstatus / -88 : [ "UpToDate" ],
                   / tcb-eval-num / -86 : 11
                 }
@@ -103,7 +103,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2020-11-11T00:00:00Z"),
+                  / tcbdate / -72 : "2020-11-11T00:00:00Z",
                   / tcbstatus / -88 : [ "OutOfDate" ],
                   / tcb-eval-num / -86 : 11
                 }
@@ -138,7 +138,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2021-06-09T00:00:00Z"),
+                  / tcbdate / -72 : "2021-06-09T00:00:00Z",
                   / tcbstatus / -88 : [ "ConfigurationNeeded" ],
                   / tcb-eval-num / -86 : 11
                 }
@@ -173,7 +173,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2020-11-11T00:00:00Z"),
+                  / tcbdate / -72 : "2020-11-11T00:00:00Z",
                   / tcbstatus / -88 : [ "OutOfDate", "ConfigurationNeeded" ],
                   / tcb-eval-num / -86 : 11
                 }

--- a/cddl/examples/irim-sgx-tcbinfo.diag
+++ b/cddl/examples/irim-sgx-tcbinfo.diag
@@ -85,7 +85,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2022-11-09T00:00:00Z"),
+                  / tcbdate / -72 : "2022-11-09T00:00:00Z",
                   / tcbstatus / -88 : [ "UpToDate" ],
                   / tcb-eval-num / -86 : 5
                 }
@@ -120,7 +120,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2020-03-22T00:00:00Z"),
+                  / tcbdate / -72 : "2020-03-22T00:00:00Z",
                   / tcbstatus / -88 : [ "OutOfDate" ],
                   / tcb-eval-num / -86 : 5
                 }
@@ -155,7 +155,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2019-01-01T00:00:00Z"),
+                  / tcbdate / -72 : "2019-01-01T00:00:00Z",
                   / tcbstatus / -88 : [ "OutOfDate", "ConfigurationNeeded" ],
                   / advisory-ids / -89 : [ "INTEL-SA-00079" ],
                   / tcb-eval-num / -86 : 5
@@ -191,7 +191,7 @@
             [ / addition /
               / measurement-map / {
                 / measurement-values-map / 1 : {
-                  / tcbdate / -72 : 0("2018-01-01T00:00:00Z"),
+                  / tcbdate / -72 : "2018-01-01T00:00:00Z",
                   / tcbstatus / -88 : [ "OutOfDate", "ConfigurationNeeded" ],
                   / advisory-ids / -89 : [ "INTEL-SA-00078", "INTEL-SA-00077" ],
                   / tcb-eval-num / -86 : 5

--- a/cddl/examples/irim-tcbdate.diag
+++ b/cddl/examples/irim-tcbdate.diag
@@ -14,7 +14,7 @@
         [
           / measurement-map / {
             / mval / 1 : {
-              / tcbdate / -72 : 0("2023-02-15T00:00:00Z")
+              / tcbdate / -72 : "2023-02-15T00:00:00Z"
             }
           },
           {
@@ -33,7 +33,13 @@
         [
           / measurement-map / {
             / mval / 1 : {
-              / tcbdate / -72 : 60010([ 2, 0("2023-02-15T01:00:00Z")]) / *** tagged-exp-tdate-ge *** /
+              / tcbdate / -72 : 60010([ 2, "2023-02-15T01:00:00Z" ]) / *** tagged-exp-tdate-ge *** /
+            }
+          },
+          / measurement-map / {
+            / mkey / 0 : "test1",
+            / mval / 1 : {
+              / tcbdate / -72 : 60010([ 2, 3600, 0("2025-02-15T01:00:00Z") ]) / *** tagged-exp-epoch-id-ge *** /
             }
           }
         ]
@@ -50,18 +56,9 @@
             / mval / 1 : {
               / tcbdate / -72 : 60010([ 2, 3600]) / *** tagged-exp-epoch-ge *** /
             }
-          }
-        ]
-      ],
-      [
-        / environment-map / {
-          / class / 0 : {
-            / class-id / 0 :
-              / tagged-uuid-type / 37(h'e5c51cb6a7fe11ed89f400155d09de33')
-          }
-        },
-        [
+          },
           / measurement-map / {
+            / mkey / 0 : "test1",
             / mval / 1 : {
               / tcbdate / -72 : 60010([ 2, -3600]) / *** tagged-exp-epoch-ge *** /
             }

--- a/cddl/tdate-expr.cddl
+++ b/cddl/tdate-expr.cddl
@@ -1,15 +1,15 @@
 tagged-exp-tdate-gt = #6.60010([ 
     gt .within tdate-operator,
-    tdate ])
+    tdate-type ])
 
 tagged-exp-tdate-ge = #6.60010([ 
     ge .within tdate-operator,
-    tdate ])
+    tdate-type ])
 
 tagged-exp-tdate-lt = #6.60010([
     lt .within tdate-operator,
-    tdate ])
+    tdate-type ])
 
 tagged-exp-tdate-le = #6.60010([
     le .within tdate-operator,
-    tdate ])
+    tdate-type ])

--- a/cddl/tdate-type.cddl
+++ b/cddl/tdate-type.cddl
@@ -1,3 +1,4 @@
 tdate-operator = numeric-operator ; converts tdate to numeric
-tdate-expression = [ tdate-operator, tdate ] ;#6.0(string)
+tdate-type = ~tdate
+tdate-expression = [ tdate-operator, tdate-type ]
 tagged-tdate-expression = #6.60010( tdate-expression )

--- a/cddl/tee-date-type.cddl
+++ b/cddl/tee-date-type.cddl
@@ -1,6 +1,7 @@
 $$measurement-values-map-extension //= (
   &(tee.tcbdate: -72) => $tee-date-type
 )
-$tee-date-type /= tdate
+$tee-date-type /= tdate-type
 $tee-date-type /= tagged-exp-tdate-ge
 $tee-date-type /= tagged-exp-epoch-ge
+$tee-date-type /= tagged-exp-epoch-id-ge

--- a/cddl/tee-epoch-type.cddl
+++ b/cddl/tee-epoch-type.cddl
@@ -3,3 +3,10 @@ $$measurement-values-map-extension //= (
 )
 $tee-epoch-type /= $epoch-timestamp-type
 $tee-epoch-type /= tagged-exp-epoch-gt
+$tee-epoch-type /= tagged-exp-epoch-ge
+$tee-epoch-type /= tagged-exp-epoch-lt
+$tee-epoch-type /= tagged-exp-epoch-le
+$tee-epoch-type /= tagged-exp-epoch-id-gt
+$tee-epoch-type /= tagged-exp-epoch-id-ge
+$tee-epoch-type /= tagged-exp-epoch-id-lt
+$tee-epoch-type /= tagged-exp-epoch-id-le

--- a/cddl/time-expr.cddl
+++ b/cddl/time-expr.cddl
@@ -1,15 +1,15 @@
 tagged-exp-time-gt = #6.60010([ 
     gt .within time-operator,
-    time ])
+    time-type ])
 
 tagged-exp-time-ge = #6.60010([ 
     ge .within time-operator,
-    time ])
+    time-type ])
 
 tagged-exp-time-lt = #6.60010([
     lt .within time-operator,
-    time ])
+    time-type ])
 
 tagged-exp-time-le = #6.60010([
     le .within time-operator,
-    time ])
+    time-type ])

--- a/cddl/time-type.cddl
+++ b/cddl/time-type.cddl
@@ -1,3 +1,4 @@
 time-operator = numeric-operator
-time-expression = [ time-operator, time ] ;#6.1(number)
+time-type = ~time ;#6.1(integer or float)
+time-expression = [ time-operator, time-type ] 
 tagged-time-expression = #6.60010( time-expression )


### PR DESCRIPTION
typing between tdate-type, time-type and epoch-type is cleaned up to make the separation more well defined.