### PR TITLE
Add uint range

### DIFF
--- a/cddl/examples/corim-0.diag
+++ b/cddl/examples/corim-0.diag
@@ -1,34 +1,34 @@
-/ *** COSE-Sign1-corim.payload ***/
-/ corim / 500(
-  / tagged-corim-map / 501(
-    {
-      / corim.id / 0 : h'284e6c3e5d9f4f6b851f5a4247f243a6',
-      / corim.tags / 1 : [
-        / tagged-concise-bom-tag / 508( <<
-          / concise-bom-tag / {
-            / tag-identity-map / 0 : {
-              / tag-id / 0 : h'1f06af63a93c11e4979700505690773f' / * example cobom tag * /
-            },
-            / tags-list / 1 : [
-              { / tag-id / 0 : h'3f06af63a93c11e4979700505690773f' } / *** the comid tag below *** /
-            ],
-            / BOM validity / 2 : {
-              / not before / 0 : 1(1686168550),
-              / not after / 1 : 1(1697179543)
-            }
+/ *** tagged-unsigned-corim-map ***/
+
+/ tagged-corim-map / 501(
+  {
+    / corim.id / 0 : h'284e6c3e5d9f4f6b851f5a4247f243a6',
+    / corim.tags / 1 : [
+      / tagged-concise-bom-tag / 508( <<
+        / concise-bom-tag / {
+          / tag-identity-map / 0 : {
+            / tag-id / 0 : h'1f06af63a93c11e4979700505690773f' / * example cobom tag * /
+          },
+          / tags-list / 1 : [
+            { / tag-id / 0 : h'3f06af63a93c11e4979700505690773f' } / *** the comid tag below *** /
+          ],
+          / BOM validity / 2 : {
+            / not before / 0 : 1(1686168550),
+            / not after / 1 : 1(1697179543)
           }
-        >> )
-      ],
-      / dependent-rims / 2 : [ / ** links to related RIMs ** /
-        { 
-          / href / 0 : 32("https://rims.example.intel.com/path/to/file_adkfhaeria-dfka_efkj.rim")
         }
-      ],
-      / Intel profile / 3 : 111(h'6086480186F84D011001'), / 2.16.840.1.113741.1.16.1 /
-      / RIM validity / 4 : {
-        / not before / 0 : 1(1686168550),
-        / not after / 1 : 1(1697179543)
+      >> )
+    ],
+    / dependent-rims / 2 : [ / ** links to related RIMs ** /
+      { 
+        / href / 0 : 32("https://rims.example.intel.com/path/to/file_adkfhaeria-dfka_efkj.rim")
       }
+    ],
+    / Intel profile / 3 : 111(h'6086480186F84D011001'), / 2.16.840.1.113741.1.16.1 /
+    / RIM validity / 4 : {
+      / not before / 0 : 1(1686168550),
+      / not after / 1 : 1(1697179543)
     }
-  )
+  }
 )
+

--- a/cddl/examples/corim-1.diag
+++ b/cddl/examples/corim-1.diag
@@ -1,116 +1,116 @@
 / *** COSE-Sign1-corim.payload ***/
-/ corim / 500(
-  / tagged-corim-map / 501(
-    {
-      / corim.id / 0 : h'284e6c3e5d9f4f6b851f5a4247f243a7',
-      / corim.tags / 1 : [
-        / tagged-concise-bom-tag / 508( <<
-          / concise-bom-tag / {
-            / tag-identity-map / 0 : {
-              / tag-id / 0 : h'1f06af63a93c11e4979700505690773f' / * example cobom tag * /
-            },
-            / tags-list / 1 : [
-              { / tag-id / 0 : h'3f06af63a93c11e4979700505690773f' }, / *** the comid tag below *** /
-              { / tag-id / 0 : "com.acme.rrd2013-ce-sp1-v4-1-5-0" } / *** the coswid tag below *** /
-            ],
-            / BOM validity / 2 : {
-              / not before / 0 : 1(1686168550),
-              / not after / 1 : 1(1697179543)
-            }
+
+/ tagged-corim-map / 501(
+  {
+    / corim.id / 0 : h'284e6c3e5d9f4f6b851f5a4247f243a7',
+    / corim.tags / 1 : [
+      / tagged-concise-bom-tag / 508( <<
+        / concise-bom-tag / {
+          / tag-identity-map / 0 : {
+            / tag-id / 0 : h'1f06af63a93c11e4979700505690773f' / * example cobom tag * /
+          },
+          / tags-list / 1 : [
+            { / tag-id / 0 : h'3f06af63a93c11e4979700505690773f' }, / *** the comid tag below *** /
+            { / tag-id / 0 : "com.acme.rrd2013-ce-sp1-v4-1-5-0" } / *** the coswid tag below *** /
+          ],
+          / BOM validity / 2 : {
+            / not before / 0 : 1(1686168550),
+            / not after / 1 : 1(1697179543)
           }
-        >> ),
-        / tagged-concise-mid-tag / 506( <<
-          / concise-mid-tag / {
-            / comid.tag-identity / 1 : {
-              / comid.tag-id / 0 : h'3f06af63a93c11e4979700505690773f' / * example comid tag * /
-            },
-            / entity / 2 : [ {
-              / entity-name / 0 : "INTEL",
-              / reg-id / 1 : 32("https://intel.com"),
-              / role / 2 : [ 1,0,2 ] / creator, tag-creator, maintainer /
-            } ],
-            / comid.triples / 4 : {
-              / comid.reference-triples / 0 : [ [
-                / environment-map / {
-                  / comid.class / 0 : {
-                    / comid.class-id / 0 :
-                      / tagged-uuid-type / 37(h'67b28b6c34cc40a19117ab5b05911e37'),
-                    / comid.vendor / 1 : "INTEL",
-                    / comid.model / 2 : "Intel Product X"
-                  }
-                },
-                [
-                  / measurement-map / {
-                    / mval / 1 : {
-                      / version-map / 0 : {
-                        / version / 0 : "1.0.0",
-                        / version-scheme / 1 : 16384 / semver /
-                      }
+        }
+      >> ),
+      / tagged-concise-mid-tag / 506( <<
+        / concise-mid-tag / {
+          / comid.tag-identity / 1 : {
+            / comid.tag-id / 0 : h'3f06af63a93c11e4979700505690773f' / * example comid tag * /
+          },
+          / entity / 2 : [ {
+            / entity-name / 0 : "INTEL",
+            / reg-id / 1 : 32("https://intel.com"),
+            / role / 2 : [ 1,0,2 ] / creator, tag-creator, maintainer /
+          } ],
+          / comid.triples / 4 : {
+            / comid.reference-triples / 0 : [ [
+              / environment-map / {
+                / comid.class / 0 : {
+                  / comid.class-id / 0 :
+                    / tagged-uuid-type / 37(h'67b28b6c34cc40a19117ab5b05911e37'),
+                  / comid.vendor / 1 : "INTEL",
+                  / comid.model / 2 : "Intel Product X"
+                }
+              },
+              [
+                / measurement-map / {
+                  / mval / 1 : {
+                    / version-map / 0 : {
+                      / version / 0 : "1.0.0",
+                      / version-scheme / 1 : 16384 / semver /
                     }
                   }
-                ]
-              ] ]
-            }
+                }
+              ]
+            ] ]
           }
-        >> ),
-        / tagged-concise-swid-tag / 505( <<
-          {
-            / tag-id / 0: "com.acme.rrd2013-ce-sp1-v4-1-5-0",
-            / tag-version / 12: 0,
-            / software-name / 1: "ACME Roadrunner Detector 2013 Coyote Edition SP1",
-             / software-version / 13: "4.1.5",
-             / software-meta / 5: {
-              / activation-status / 43: "trial",
-              / colloquial-version / 45: "2013",
-              / edition / 47: "coyote",
-              / product / 52: "Roadrunner Detector",
-              / revision / 54: "sp1"
-             },
-            / entity-entry / 2: [
-              {
-                / entity-name / 31: "The ACME Corporation",
-                / reg-id / 32: 32("acme.com"), 
-                / role / 33: [ / tag-creator / 1, / software-creator / 2]
-              },
-              {
-                / entity-name / 31: "Coyote Services, Inc.",
-                / reg-id / 32: 32("mycoyote.com"),
-                / role / 33: / distributor / 4
-              }
-            ],
-            / link-entry / 4: {
-              / href / 38: 32("www.gnu.org/licenses/gpl.txt"),
-              / rel / 40: "license"
+        }
+      >> ),
+      / tagged-concise-swid-tag / 505( <<
+        {
+          / tag-id / 0: "com.acme.rrd2013-ce-sp1-v4-1-5-0",
+          / tag-version / 12: 0,
+          / software-name / 1: "ACME Roadrunner Detector 2013 Coyote Edition SP1",
+            / software-version / 13: "4.1.5",
+            / software-meta / 5: {
+            / activation-status / 43: "trial",
+            / colloquial-version / 45: "2013",
+            / edition / 47: "coyote",
+            / product / 52: "Roadrunner Detector",
+            / revision / 54: "sp1"
             },
-            / payload / 6: {
-              / directory / 16: {
-                / fs-name / 24: "rrdetector",
-                / root / 25: "%programdata%",
-                / path-elements / 26: {
-                  / file / 17: {
-                    / fs-name / 24: "rrdetector.exe",
-                    / size / 20: 532712,
-                    / hash / 7: [
-                      / alg-id / 1,
-                      / digest / h'A314FC2DC663AE7A6B6BC6787594057396E6B3F569CD50FD5DDB4D1BBAFD2B6A'
-                    ]
-                  }
+          / entity-entry / 2: [
+            {
+              / entity-name / 31: "The ACME Corporation",
+              / reg-id / 32: 32("acme.com"), 
+              / role / 33: [ / tag-creator / 1, / software-creator / 2]
+            },
+            {
+              / entity-name / 31: "Coyote Services, Inc.",
+              / reg-id / 32: 32("mycoyote.com"),
+              / role / 33: / distributor / 4
+            }
+          ],
+          / link-entry / 4: {
+            / href / 38: 32("www.gnu.org/licenses/gpl.txt"),
+            / rel / 40: "license"
+          },
+          / payload / 6: {
+            / directory / 16: {
+              / fs-name / 24: "rrdetector",
+              / root / 25: "%programdata%",
+              / path-elements / 26: {
+                / file / 17: {
+                  / fs-name / 24: "rrdetector.exe",
+                  / size / 20: 532712,
+                  / hash / 7: [
+                    / alg-id / 1,
+                    / digest / h'A314FC2DC663AE7A6B6BC6787594057396E6B3F569CD50FD5DDB4D1BBAFD2B6A'
+                  ]
                 }
               }
             }
           }
-        >> )
-      ],
-      / dependent-rims / 2 : [ / ** links to related RIMs ** /
-        { 
-          / href / 0 : 32("https://rims.example.intel.com/path/to/file_adkfhaeria-dfka_efkj.rim")
         }
-      ],
-      / Intel profile / 3 : 111(h'6086480186F84D011001'), / 2.16.840.1.113741.1.16.1 /
-      / RIM validity / 4 : {
-        / not before / 0 : 1(1686168550),
-        / not after / 1 : 1(1697179543)
+      >> )
+    ],
+    / dependent-rims / 2 : [ / ** links to related RIMs ** /
+      { 
+        / href / 0 : 32("https://rims.example.intel.com/path/to/file_adkfhaeria-dfka_efkj.rim")
       }
+    ],
+    / Intel profile / 3 : 111(h'6086480186F84D011001'), / 2.16.840.1.113741.1.16.1 /
+    / RIM validity / 4 : {
+      / not before / 0 : 1(1686168550),
+      / not after / 1 : 1(1697179543)
     }
-  )
+  }
 )
+

--- a/cddl/examples/irim-0test.diag
+++ b/cddl/examples/irim-0test.diag
@@ -21,7 +21,7 @@
         [
           / measurement-map / {
             / mval / 1 : { / *** measurement-values-map *** /
-              / tee.attributes mask / -82 : 60040([ / op.eq / 0, h'0003', h'0003' ]),
+              / tee.attributes / -82 : 563([ h'00000000', h'FBFFFFFF' ]),
               / tcb-eval-num / -86 : 60010([ / op.ge / 2, 11 ]),
               / mrsigner / -84 : 60020([ / op.mem / 6, 
                 / digests-type / [

--- a/cddl/examples/irim-0test.diag
+++ b/cddl/examples/irim-0test.diag
@@ -22,7 +22,6 @@
           / measurement-map / {
             / mval / 1 : { / *** measurement-values-map *** /
               / tee.attributes / -82 : 563([ h'00000000', h'FBFFFFFF' ]),
-              / tcb-eval-num / -86 : 60010([ / op.ge / 2, 11 ]),
               / mrsigner / -84 : 60020([ / op.mem / 6, 
                 / digests-type / [
                   [

--- a/cddl/examples/irim-1test.diag
+++ b/cddl/examples/irim-1test.diag
@@ -31,19 +31,29 @@
               / advisory-ids /  -89 : 60021([ /member/ 6, [ "INTEL-SA-00078", "INTEL-SA-00079"  ]]),
               / isvprodid / -85 : 1
             }
-          },
-          / measurement-map / {
-            / mkey / 0 : 1,
-            / mval / 1 : / measurement-values-map / {
-              / advisory-ids /  -89 : [ ],
-              / tcbstatus /  -88 : [ ]
+          }, 
+          / *** tcb-eval-num examples ***/
+            / measurement-map / {
+            / mval / 1 : / measurement-values-map / { 
+              / tcb-eval-num / -86 : 11 / *** as exact match *** / 
             }
           },
-           / measurement-map / {
-            / mkey / 0 : 2,
-            / mval / 1 : / measurement-values-map / {
-              / advisory-ids /  -89 : 60021([ /not-member/ 7, [ "NOT-AN-SA" ]]),
-              / tcbstatus /  -89 : 60021([ /not-member/ 7, [ "OutOfDate", "SWHardeningNeeded", "ConfigurationNeeded" ]])
+          / measurement-map / {
+            / mkey / 0 : "tagged-uint-range example",
+            / mval / 1 : / measurement-values-map / { 
+              / tcb-eval-num / -86 : 60011([/min:/ 11, /max:/ null ]) 
+            }
+          },
+          / measurement-map / {
+            / mkey / 0 : "tagged-numeric-ge example",
+            / mval / 1 : / measurement-values-map / { 
+              / tcb-eval-num / -86 : 60010([ / op.ge / 2, 11 ]) 
+            }
+          },
+          / measurement-map / {
+            / mkey / 0 : 86, / tcb-eval-num /
+            / mval / 1 : / measurement-values-map / { 
+              / raw-uint / -1 : 60011([/min:/ 11, /max:/ null ])  
             }
           }
         ]
@@ -57,11 +67,6 @@
           }
         },
         [
-          / measurement-map / {
-            / mval / 1 : / measurement-values-map / { 
-              / tcb-eval-num / -86 : 11 / *** endorsement *** / 
-            }
-          },
           / measurement-map / {
             / mkey / 0 : "mask examples simple",
             / mval / 1 : / measurement-values-map / { 
@@ -81,6 +86,20 @@
             / mkey / 0 : 81, / mask examples tagged-masked-raw-value /
             / mval / 1 : / measurement-values-map / { 
               / raw-value / 4 : 563([ h'00000000', h'FBFFFFFF' ])
+            }
+          },
+          / measurement-map / {
+            / mkey / 0 : 1,
+            / mval / 1 : / measurement-values-map / {
+              / advisory-ids /  -89 : [ ],
+              / tcbstatus /  -88 : [ ]
+            }
+          },
+           / measurement-map / {
+            / mkey / 0 : 2,
+            / mval / 1 : / measurement-values-map / {
+              / advisory-ids /  -89 : 60021([ /not-member/ 7, [ "NOT-AN-SA" ]]),
+              / tcbstatus /  -89 : 60021([ /not-member/ 7, [ "OutOfDate", "SWHardeningNeeded", "ConfigurationNeeded" ]])
             }
           }
         ]

--- a/cddl/examples/irim-1test.diag
+++ b/cddl/examples/irim-1test.diag
@@ -15,8 +15,6 @@
             / mval / 1 : / measurement-values-map / { 
               / tcbdate / -72 : "2023-06-09T00:00:00Z", / *** ~tdate *** /
               / isvsvn / -73 : 60010([ / op.ge / 2, 6 ]),
-              / miscselect / -81 : 60040([ / mask-eq / 0, h'00000000', h'FBFFFFFF' ]),
-              / attributes / -82 : 60040([ / mask-eq / 0, h'C0000000000000000000000000000000', h'FBFFFFFFFFFFFFFF0000000000000000' ]),
               / mrsigner / -84 : 60020([ / member / 6, 
                 [
                   [ / digest-type / 
@@ -62,6 +60,27 @@
           / measurement-map / {
             / mval / 1 : / measurement-values-map / { 
               / tcb-eval-num / -86 : 11 / *** endorsement *** / 
+            }
+          },
+          / measurement-map / {
+            / mkey / 0 : "mask examples simple",
+            / mval / 1 : / measurement-values-map / { 
+              / miscselect / -81 : h'00000000',
+              / attributes / -82 : h'C0000000000000000000000000000000',
+              / raw-value / 4 : 560(h'00000000')
+            }
+          },
+          / measurement-map / {
+            / mkey / 0 : "mask examples tagged-masked-raw-value profile",
+            / mval / 1 : / measurement-values-map / { 
+              / miscselect / -81 : 563([ h'00000000', h'FBFFFFFF' ]),
+              / attributes / -82 : 563([ h'C0000000000000000000000000000000', h'FBFFFFFFFFFFFFFF0000000000000000' ])
+            }
+          },
+          / measurement-map / {
+            / mkey / 0 : 81, / mask examples tagged-masked-raw-value /
+            / mval / 1 : / measurement-values-map / { 
+              / raw-value / 4 : 563([ h'00000000', h'FBFFFFFF' ])
             }
           }
         ]

--- a/cddl/examples/irim-isve-ref-end.diag
+++ b/cddl/examples/irim-isve-ref-end.diag
@@ -13,8 +13,8 @@
         [
           / measurement-map / {
             / mval / 1 : / measurement-values-map / { 
-              / miscselect / -81 : 60040([ / mask-eq / 0, h'00000000', h'FBFFFFFF' ]),
-              / attributes / -82 : 60040([ / mask-eq / 0, h'C0000000000000000000000000000000', h'FBFFFFFFFFFFFFFF0000000000000000' ]),
+              / miscselect / -81 : 563([ h'00000000', h'FBFFFFFF' ]),
+              / attributes / -82 : 563([ h'C0000000000000000000000000000000', h'FBFFFFFFFFFFFFFF0000000000000000' ]),
               / isvsvn / -73 : 60010([ / op.ge / 2, 6 ]),
               / advisory-ids /  -89 : 60021([ /member/ 6, [ "INTEL-SA-00078", "INTEL-SA-00079"  ]]),
               / tcbstatus /  -88 : 60021([ /member/ 6, [ "UpToDate"  ]]),

--- a/cddl/examples/irim-qe-cend.diag
+++ b/cddl/examples/irim-qe-cend.diag
@@ -43,8 +43,8 @@
           [
             / measurement-map / {
               / mval / 1 : / measurement-values-map / {
-                / miscselect / -81 : 60040([ / mask-eq / 0, h'00000000', h'FFFFFFFF' ]),
-                / attributes / -82 : 60040([ / mask-eq / 0, h'11000000000000000000000000000000', h'FBFFFFFFFFFFFFFF0000000000000000']), / *** 16 bytes *** /
+                / miscselect / -81 : 563([ h'00000000', h'FFFFFFFF' ]),
+                / attributes / -82 : 563([ h'11000000000000000000000000000000', h'FBFFFFFFFFFFFFFF0000000000000000']), / *** 16 bytes *** /
                 / mrsigner / -84 : 60020([ / op.member / 6, 
                   / digests-type / [
                     [

--- a/cddl/examples/irim-qe-ref.diag
+++ b/cddl/examples/irim-qe-ref.diag
@@ -17,7 +17,7 @@
             / measurement-map / {
               / mval / 1 : { / *** measurement-values-map *** /
                 / tcb-eval-num / -86 : 60010([ / op.ge / 2, 11 ]), 
-                / miscselect / -81 : 60040([ / mask-eq / 0, h'C0000000', h'FBFF0000' ]),
+                / miscselect / -81 : 563([ h'C0000000', h'FBFF0000' ]),
                 / mrsigner / -84 : 60020([ / op.member / 6, 
                   / digests-type / [
                     [

--- a/cddl/examples/irim-seam-crs.diag
+++ b/cddl/examples/irim-seam-crs.diag
@@ -17,7 +17,7 @@
               / mval / 1 : / measurement-values-map / {
                 / vendor / -70 : "Intel Corporation",
                 / model / -71 : "TDX SEAM",
-                / attributes / -82 : 60040([ / mask-eq / 0, h'C0000000000000000000000000000000', h'FBFFFFFFFFFFFFFF0000000000000000']), / *** 16 bytes *** /
+                / attributes / -82 : 563([ h'C0000000000000000000000000000000', h'FBFFFFFFFFFFFFFF0000000000000000']), / *** 16 bytes *** /
                 / isvprodid / -85 : 1,
                 / isvsvn / -73 : 60010([ /op.ge/ 2, 6 ]),
                 / mrsigner / -84 : [

--- a/cddl/examples/irim-sgx-tcbinfo.diag
+++ b/cddl/examples/irim-sgx-tcbinfo.diag
@@ -44,7 +44,7 @@
             / measurement-map / {
               / mval / 1 : / measurement-values-map / {
                 / pceid / -80 : "0000",
-                / tee.attributes mask / -82 : 60040([ / op.mask-eq / 0, h'0003', h'0003' ])
+                / tee.attributes mask / -82 : 563([ h'0003', h'FFF0' ])
               },
               / authorized-by / 2 : [
                 / tagged-pkix-base64-key-type / 554("base64_key_for-RIM-creator")

--- a/cddl/funcs.mk
+++ b/cddl/funcs.mk
@@ -3,6 +3,9 @@
 define cddl_autogen_template
 check-$(1): $(1)-autogen.cddl
 
+# Generate rfc9581 cddl into autoconfig - uncomment when debugged
+# %.cddl: %.cddlx ; echo cddlc ; cddlc -2tcddl $$< > $$@
+
 $(1)-autogen.cddl: $(2)
 	echo ">>> generating" $(1)"-autogen.cddl"
 	for f in $$^ ; do ( grep -v '^;' $$$$f ; echo ) ; done > $$@

--- a/cddl/funcs.mk
+++ b/cddl/funcs.mk
@@ -4,7 +4,7 @@ define cddl_autogen_template
 check-$(1): $(1)-autogen.cddl
 
 # Generate rfc9581 cddl into autoconfig - uncomment when debugged
-# %.cddl: %.cddlx ; echo cddlc ; cddlc -2tcddl $$< > $$@
+#%.cddl: %.cddlx ; echo cddlc ; cddlc -2tcddl $$< > $$@
 
 $(1)-autogen.cddl: $(2)
 	echo ">>> generating" $(1)"-autogen.cddl"

--- a/cddl/imports/Makefile
+++ b/cddl/imports/Makefile
@@ -7,7 +7,8 @@ include ../funcs.mk
 
 check:: import-ce import-corim
 
-IDATE := 2025-01-07
+CORIM_IDATE := 2025-03-31
+CE_IDATE := 2025-01-07
 
-$(eval $(call cddl_imports_template,ce,$(IDATE)))
-$(eval $(call cddl_imports_template,corim,$(IDATE)))
+$(eval $(call cddl_imports_template,ce,$(CE_IDATE)))
+$(eval $(call cddl_imports_template,corim,$(CORIM_IDATE)))

--- a/cddl/imports/corim-2025-03-31.cddl
+++ b/cddl/imports/corim-2025-03-31.cddl
@@ -1,0 +1,663 @@
+corim = concise-rim-type-choice
+
+concise-rim-type-choice /= tagged-unsigned-corim-map
+concise-rim-type-choice /= signed-corim
+
+concise-tl-tag = {
+  &(tag-identity: 0) => tag-identity-map
+  &(tags-list: 1) => [ + tag-identity-map ],
+  &(tl-validity: 2) => validity-map
+}
+
+$concise-tag-type-choice /= tagged-concise-swid-tag
+$concise-tag-type-choice /= tagged-concise-mid-tag
+$concise-tag-type-choice /= tagged-concise-tl-tag
+
+corim-entity-map =
+  entity-map<$corim-role-type-choice, $$corim-entity-map-extension>
+
+$corim-id-type-choice /= tstr
+$corim-id-type-choice /= uuid-type
+
+corim-locator-map = {
+  &(href: 0) => uri / [ + uri ]
+  ? &(thumbprint: 1) => digest
+}
+
+corim-map = {
+  &(id: 0) => $corim-id-type-choice
+  &(tags: 1) => [ + $concise-tag-type-choice ]
+  ? &(dependent-rims: 2) => [ + corim-locator-map ]
+  ? &(profile: 3) => $profile-type-choice
+  ? &(rim-validity: 4) => validity-map
+  ? &(entities: 5) => [ + corim-entity-map ]
+  * $$corim-map-extension
+}
+unsigned-corim-map = corim-map
+
+corim-meta-map = {
+  &(signer: 0) => corim-signer-map
+  ? &(signature-validity: 1) => validity-map
+}
+
+$corim-role-type-choice /= &(manifest-creator: 1)
+$corim-role-type-choice /= &(manifest-signer: 2)
+
+corim-signer-map = {
+  &(signer-name: 0) => $entity-name-type-choice
+  ? &(signer-uri: 1) => uri
+  * $$corim-signer-map-extension
+}
+
+COSE-Sign1-corim = [
+  protected: bstr .cbor protected-corim-header-map
+  unprotected: unprotected-corim-header-map
+  payload: bstr .cbor tagged-unsigned-corim-map
+  signature: bstr
+]
+
+$profile-type-choice /= uri 
+$profile-type-choice /= tagged-oid-type
+
+protected-corim-header-map = {
+  &(alg: 1) => int
+  &(content-type: 3) => "application/rim+cbor"
+  &(kid: 4) => bstr
+  &(corim-meta: 8) => bstr .cbor corim-meta-map
+  * cose-label => cose-value
+}
+
+signed-corim = #6.18(COSE-Sign1-corim)
+
+tagged-concise-swid-tag = #6.505(bytes .cbor concise-swid-tag)
+
+tagged-concise-mid-tag = #6.506(bytes .cbor concise-mid-tag)
+
+tagged-concise-tl-tag = #6.508(bytes .cbor concise-tl-tag)
+
+tagged-unsigned-corim-map = #6.501(unsigned-corim-map)
+
+unprotected-corim-header-map = {
+  * cose-label => cose-value
+}
+
+validity-map = {
+  ? &(not-before: 0) => time
+  &(not-after: 1) => time
+}
+
+concise-mid-tag = {
+  ? &(language: 0) => text
+  &(tag-identity: 1) => tag-identity-map
+  ? &(entities: 2) => [ + comid-entity-map ]
+  ? &(linked-tags: 3) => [ + linked-tag-map ]
+  &(triples: 4) => triples-map
+  * $$concise-mid-tag-extension
+}
+
+attest-key-triple-record = [
+  environment: environment-map
+  key-list: [ + $crypto-key-type-choice ]
+  ? conditions: non-empty< {
+    ? &(mkey: 0) => $measured-element-type-choice,
+    ? &(authorized-by: 1) => [ + $crypto-key-type-choice ]
+  }>
+]
+
+$class-id-type-choice /= tagged-oid-type
+$class-id-type-choice /= tagged-uuid-type
+$class-id-type-choice /= tagged-bytes
+
+class-map = non-empty<{
+  ? &(class-id: 0) => $class-id-type-choice
+  ? &(vendor: 1) => tstr
+  ? &(model: 2) => tstr
+  ? &(layer: 3) => uint
+  ? &(index: 4) => uint
+}>
+
+comid-entity-map =
+  entity-map<$comid-role-type-choice, $$comid-entity-map-extension>
+
+$comid-role-type-choice /= &(tag-creator: 0)
+$comid-role-type-choice /= &(creator: 1)
+$comid-role-type-choice /= &(maintainer: 2)
+
+conditional-endorsement-series-triple-record = [
+  condition: stateful-environment-record
+  series: [ + conditional-series-record ]
+]
+
+conditional-series-record = [
+  selection: [ + measurement-map]
+  addition: [ + measurement-map ]
+]
+
+COSE_KeySet = [ + COSE_Key ]
+
+COSE_Key = {
+    1 => tstr / int
+    ? 2 => bstr 
+    ? 3 => tstr / int 
+    ? 4 => [+ (tstr / int) ]
+    ? 5 => bstr
+    * cose-label => cose-value
+}
+
+cose-label = int / tstr
+cose-value = any
+
+coswid-triple-record = [
+  environment-map
+  [ + concise-swid-tag-id ]
+]
+
+concise-swid-tag-id = text / bstr .size 16
+
+$crypto-key-type-choice /= tagged-pkix-base64-key-type
+$crypto-key-type-choice /= tagged-pkix-base64-cert-type
+$crypto-key-type-choice /= tagged-pkix-base64-cert-path-type
+$crypto-key-type-choice /= tagged-cose-key-type
+$crypto-key-type-choice /= tagged-thumbprint-type
+$crypto-key-type-choice /= tagged-cert-thumbprint-type
+$crypto-key-type-choice /= tagged-cert-path-thumbprint-type
+$crypto-key-type-choice /= tagged-pkix-asn1der-cert-type
+$crypto-key-type-choice /= tagged-bytes
+
+tagged-pkix-base64-key-type = #6.554(tstr)
+tagged-pkix-base64-cert-type = #6.555(tstr)
+tagged-pkix-base64-cert-path-type = #6.556(tstr)
+tagged-thumbprint-type = #6.557(digest)
+tagged-cose-key-type = #6.558(COSE_KeySet / COSE_Key)
+tagged-cert-thumbprint-type = #6.559(digest)
+tagged-cert-path-thumbprint-type = #6.561(digest)
+tagged-pkix-asn1der-cert-type = #6.562(bstr)
+
+domain-dependency-triple-record = [
+  $domain-type-choice
+  [ + $domain-type-choice ]
+]
+
+domain-membership-triple-record = [
+  $domain-type-choice
+  [ + environment-map ]
+]
+
+conditional-endorsement-triple-record = [
+  conditions: [ + stateful-environment-record ]
+  endorsements: [ + endorsed-triple-record ]
+]
+
+$domain-type-choice /= uint
+$domain-type-choice /= text
+$domain-type-choice /= tagged-uuid-type
+$domain-type-choice /= tagged-oid-type
+
+endorsed-triple-record = [
+  condition: environment-map
+  endorsement: [ + measurement-map ]
+]
+
+entity-map<role-type-choice, extension-socket> = {
+  &(entity-name: 0) => $entity-name-type-choice
+  ? &(reg-id: 1) => uri
+  &(role: 2) => [ + role-type-choice ]
+  * extension-socket
+}
+
+$entity-name-type-choice /= text
+
+environment-map = non-empty<{
+  ? &(class: 0) => class-map
+  ? &(instance: 1) => $instance-id-type-choice
+  ? &(group: 2) => $group-id-type-choice
+}>
+
+flags-map = {
+  ? &(is-configured: 0) => bool
+  ? &(is-secure: 1) => bool
+  ? &(is-recovery: 2) => bool
+  ? &(is-debug: 3) => bool
+  ? &(is-replay-protected: 4) => bool
+  ? &(is-integrity-protected: 5) => bool
+  ? &(is-runtime-meas: 6) => bool
+  ? &(is-immutable: 7) => bool
+  ? &(is-tcb: 8) => bool
+  ? &(is-confidentiality-protected: 9) => bool
+  * $$flags-map-extension
+}
+
+$group-id-type-choice /= tagged-uuid-type
+$group-id-type-choice /= tagged-bytes
+
+identity-triple-record = [
+  environment: environment-map
+  key-list: [ + $crypto-key-type-choice ]
+  ? conditions: non-empty<{
+    ? &(mkey: 0) => $measured-element-type-choice,
+    ? &(authorized-by: 1) => [ + $crypto-key-type-choice ] 
+  }>
+]
+
+$instance-id-type-choice /= tagged-ueid-type
+$instance-id-type-choice /= tagged-uuid-type
+$instance-id-type-choice /= $crypto-key-type-choice
+$instance-id-type-choice /= tagged-bytes
+
+ip-addr-type-choice = ip4-addr-type / ip6-addr-type
+ip4-addr-type = bytes .size 4
+ip6-addr-type = bytes .size 16
+
+raw-int-type-choice = int / tagged-int-range
+int-range = [min: int / negative-inf, max: int / positive-inf]
+tagged-int-range = #6.564(int-range)
+positive-inf = null
+negative-inf = null
+
+linked-tag-map = {
+  &(linked-tag-id: 0) => $tag-id-type-choice
+  &(tag-rel: 1) => $tag-rel-type-choice
+}
+
+mac-addr-type-choice = eui48-addr-type / eui64-addr-type
+eui48-addr-type = bytes .size 6
+eui64-addr-type = bytes .size 8
+
+$measured-element-type-choice /= tagged-oid-type
+$measured-element-type-choice /= tagged-uuid-type
+$measured-element-type-choice /= uint
+$measured-element-type-choice /= tstr
+
+measurement-map = {
+  ? &(mkey: 0) => $measured-element-type-choice
+  &(mval: 1) => measurement-values-map
+  ? &(authorized-by: 2) => [ + $crypto-key-type-choice ]
+}
+
+measurement-values-map = non-empty<{
+  ? &(version: 0) => version-map
+  ? &(svn: 1) => svn-type-choice
+  ? &(digests: 2) => digests-type
+  ? &(flags: 3) => flags-map
+  ? (
+      &(raw-value: 4) => $raw-value-type-choice,
+      ? &(raw-value-mask: 5) => raw-value-mask-type
+    )
+  ? &(mac-addr: 6) => mac-addr-type-choice
+  ? &(ip-addr: 7) =>  ip-addr-type-choice
+  ? &(serial-number: 8) => text
+  ? &(ueid: 9) => ueid-type
+  ? &(uuid: 10) => uuid-type
+  ? &(name: 11) => text
+  ? &(cryptokeys: 13) => [ + $crypto-key-type-choice ]
+  ? &(integrity-registers: 14) => integrity-registers
+  ? &(raw-int: 15) => raw-int-type-choice
+  * $$measurement-values-map-extension
+}>
+
+non-empty<M> = (M) .and ({ + any => any })
+
+oid-type = bytes
+tagged-oid-type = #6.111(oid-type)
+
+$raw-value-type-choice /= tagged-bytes
+$raw-value-type-choice /= tagged-masked-raw-value
+
+raw-value-mask-type = bytes
+
+tagged-masked-raw-value = #6.563([
+  value: bytes
+  mask : bytes
+])
+
+reference-triple-record = [
+  ref-env: environment-map
+  ref-claims: [ + measurement-map ]
+]
+
+stateful-environment-record = [
+  environment: environment-map,
+  claims-list: [ + measurement-map ]
+]
+
+svn-type = uint
+svn = svn-type
+min-svn = svn-type
+tagged-svn = #6.552(svn)
+tagged-min-svn = #6.553(min-svn)
+svn-type-choice = svn / tagged-svn / tagged-min-svn
+
+$tag-id-type-choice /= tstr
+$tag-id-type-choice /= uuid-type
+
+tag-identity-map = {
+  &(tag-id: 0) => $tag-id-type-choice
+  ? &(tag-version: 1) => tag-version-type
+}
+
+$tag-rel-type-choice /= &(supplements: 0)
+$tag-rel-type-choice /= &(replaces: 1)
+
+tag-version-type = uint .default 0
+
+tagged-bytes = #6.560(bytes)
+
+triples-map = non-empty<{
+  ? &(reference-triples: 0) =>
+    [ + reference-triple-record ]
+  ? &(endorsed-triples: 1) =>
+    [ + endorsed-triple-record ]
+  ? &(identity-triples: 2) =>
+    [ + identity-triple-record ]
+  ? &(attest-key-triples: 3) =>
+    [ + attest-key-triple-record ]
+  ? &(dependency-triples: 4) =>
+    [ + domain-dependency-triple-record ]
+  ? &(membership-triples: 5) =>
+    [ + domain-membership-triple-record ]
+  ? &(coswid-triples: 6) =>
+    [ + coswid-triple-record ]
+  ? &(conditional-endorsement-series-triples: 8) =>
+    [ + conditional-endorsement-series-triple-record ]
+  ? &(conditional-endorsement-triples: 10) =>
+    [ + conditional-endorsement-triple-record ]
+  * $$triples-map-extension
+}>
+
+ueid-type = bytes .size (7..33)
+tagged-ueid-type = #6.550(ueid-type)
+
+uuid-type = bytes .size 16
+tagged-uuid-type = #6.37(uuid-type)
+
+version-map = {
+  &(version: 0) => text
+  ? &(version-scheme: 1) => $version-scheme
+}
+
+digest = [
+  alg: (int / text),
+  val: bytes
+]
+
+digests-type = [ + digest ]
+
+integrity-register-id-type-choice = uint / text
+
+integrity-registers = {
+  + integrity-register-id-type-choice => digests-type
+}
+
+concise-swid-tag = {
+  tag-id => text / bstr .size 16,
+  tag-version => integer,
+  ? corpus => bool,
+  ? patch => bool,
+  ? supplemental => bool,
+  software-name => text,
+  ? software-version => text,
+  ? version-scheme => $version-scheme,
+  ? media => text,
+  ? software-meta => one-or-more<software-meta-entry>,
+  entity => one-or-more<entity-entry>,
+  ? link => one-or-more<link-entry>,
+  ? payload-or-evidence,
+  * $$coswid-extension,
+  global-attributes,
+}
+
+payload-or-evidence //= ( payload => payload-entry )
+payload-or-evidence //= ( evidence => evidence-entry )
+
+any-uri = uri
+label = text / int
+
+$version-scheme /= multipartnumeric
+$version-scheme /= multipartnumeric-suffix
+$version-scheme /= alphanumeric
+$version-scheme /= decimal
+$version-scheme /= semver
+$version-scheme /= int / text
+
+any-attribute = (
+  label => one-or-more<text> / one-or-more<int>
+)
+
+one-or-more<T> = T / [ 2* T ]
+
+global-attributes = (
+  ? lang => text,
+  * any-attribute,
+)
+
+hash-entry = [
+  hash-alg-id: int,
+  hash-value: bytes,
+]
+
+entity-entry = {
+  entity-name => text,
+  ? reg-id => any-uri,
+  role => one-or-more<$role>,
+  ? thumbprint => hash-entry,
+  * $$entity-extension,
+  global-attributes,
+}
+
+$role /= tag-creator
+$role /= software-creator
+$role /= aggregator
+$role /= distributor
+$role /= licensor
+$role /= maintainer
+$role /= int / text
+
+link-entry = {
+  ? artifact => text,
+  href => any-uri,
+  ? media => text,
+  ? ownership => $ownership,
+  rel => $rel,
+  ? media-type => text,
+  ? use => $use,
+  * $$link-extension,
+  global-attributes,
+}
+
+$ownership /= shared
+$ownership /= private
+$ownership /= abandon
+$ownership /= int / text
+
+$rel /= ancestor
+$rel /= component
+$rel /= feature
+$rel /= installationmedia
+$rel /= packageinstaller
+$rel /= parent
+$rel /= patches
+$rel /= requires
+$rel /= see-also
+$rel /= supersedes
+$rel /= supplemental
+$rel /= -256..64436 / text
+
+$use /= optional
+$use /= required
+$use /= recommended
+$use /= int / text
+
+software-meta-entry = {
+  ? activation-status => text,
+  ? channel-type => text,
+  ? colloquial-version => text,
+  ? description => text,
+  ? edition => text,
+  ? entitlement-data-required => bool,
+  ? entitlement-key => text,
+  ? generator =>  text / bstr .size 16,
+  ? persistent-id => text,
+  ? product => text,
+  ? product-family => text,
+  ? revision => text,
+  ? summary => text,
+  ? unspsc-code => text,
+  ? unspsc-version => text,
+  * $$software-meta-extension,
+  global-attributes,
+}
+
+path-elements-group = ( ? directory => one-or-more<directory-entry>,
+                        ? file => one-or-more<file-entry>,
+                      )
+
+resource-collection = (
+  path-elements-group,
+  ? process => one-or-more<process-entry>,
+  ? resource => one-or-more<resource-entry>,
+  * $$resource-collection-extension,
+)
+
+file-entry = {
+  filesystem-item,
+  ? size => uint,
+  ? file-version => text,
+  ? hash => hash-entry,
+  * $$file-extension,
+  global-attributes,
+}
+
+directory-entry = {
+  filesystem-item,
+  ? path-elements => { path-elements-group },
+  * $$directory-extension,
+  global-attributes,
+}
+
+process-entry = {
+  process-name => text,
+  ? pid => integer,
+  * $$process-extension,
+  global-attributes,
+}
+
+resource-entry = {
+  type => text,
+  * $$resource-extension,
+  global-attributes,
+}
+
+filesystem-item = (
+  ? key => bool,
+  ? location => text,
+  fs-name => text,
+  ? root => text,
+)
+
+payload-entry = {
+  resource-collection,
+  * $$payload-extension,
+  global-attributes,
+}
+
+evidence-entry = {
+  resource-collection,
+  ? date => integer-time,
+  ? device-id => text,
+  ? location => text,
+  * $$evidence-extension,
+  global-attributes,
+}
+
+integer-time = #6.1(int)
+
+tag-id = 0
+software-name = 1
+entity = 2
+evidence = 3
+link = 4
+software-meta = 5
+payload = 6
+hash = 7
+corpus = 8
+patch = 9
+media = 10
+supplemental = 11
+tag-version = 12
+software-version = 13
+version-scheme = 14
+lang = 15
+directory = 16
+file = 17
+process = 18
+resource = 19
+size = 20
+file-version = 21
+key = 22
+location = 23
+fs-name = 24
+root = 25
+path-elements = 26
+process-name = 27
+pid = 28
+type = 29
+entity-name = 31
+reg-id = 32
+role = 33
+thumbprint = 34
+date = 35
+device-id = 36
+artifact = 37
+href = 38
+ownership = 39
+rel = 40
+media-type = 41
+use = 42
+activation-status = 43
+channel-type = 44
+colloquial-version = 45
+description = 46
+edition = 47
+entitlement-data-required = 48
+entitlement-key = 49
+generator = 50
+persistent-id = 51
+product = 52
+product-family = 53
+revision = 54
+summary = 55
+unspsc-code = 56
+unspsc-version = 57
+
+multipartnumeric = 1
+multipartnumeric-suffix = 2
+alphanumeric = 3
+decimal = 4
+semver = 16384
+
+tag-creator=1
+software-creator=2
+aggregator=3
+distributor=4
+licensor=5
+maintainer=6
+
+abandon=1
+private=2
+shared=3
+
+ancestor=1
+component=2
+feature=3
+installationmedia=4
+packageinstaller=5
+parent=6
+patches=7
+requires=8
+see-also=9
+supersedes=10
+
+optional=1
+required=2
+recommended=3
+

--- a/cddl/mask-expr.cddl
+++ b/cddl/mask-expr.cddl
@@ -1,1 +1,0 @@
-;tagged-exp-mask-eq = #6.60040([ op.eq .within mask-operators, value: mask-type, mask: mask-type ] )

--- a/cddl/mask-expr.cddl
+++ b/cddl/mask-expr.cddl
@@ -1,1 +1,1 @@
-tagged-exp-mask-eq = #6.60040([ op.eq .within mask-operators, value: mask-type, mask: mask-type ] )
+;tagged-exp-mask-eq = #6.60040([ op.eq .within mask-operators, value: mask-type, mask: mask-type ] )

--- a/cddl/mask-type.cddl
+++ b/cddl/mask-type.cddl
@@ -1,4 +1,3 @@
-mask-operators /= op.eq
 mask-type = bstr
-mask-expression = [ mask-operators, value: mask-type, mask: mask-type]
-tagged-mask-expression = #6.60040( mask-expression )
+$masked-value-type /= mask-type
+$masked-value-type /= tagged-masked-raw-value

--- a/cddl/profile-frags.mk
+++ b/cddl/profile-frags.mk
@@ -7,7 +7,6 @@ PROFILE_FRAGS += set-expr.cddl
 PROFILE_FRAGS += set-of-set-type.cddl
 PROFILE_FRAGS += set-of-set-expr.cddl
 PROFILE_FRAGS += mask-type.cddl
-PROFILE_FRAGS += mask-expr.cddl
 PROFILE_FRAGS += tee-advisory-ids-type.cddl
 PROFILE_FRAGS += tee-attributes-type.cddl
 PROFILE_FRAGS += tee-cryptokey-type.cddl

--- a/cddl/profile-frags.mk
+++ b/cddl/profile-frags.mk
@@ -7,6 +7,7 @@ PROFILE_FRAGS += set-expr.cddl
 PROFILE_FRAGS += set-of-set-type.cddl
 PROFILE_FRAGS += set-of-set-expr.cddl
 PROFILE_FRAGS += mask-type.cddl
+PROFILE_FRAGS += raw-uint.cddl
 PROFILE_FRAGS += tee-advisory-ids-type.cddl
 PROFILE_FRAGS += tee-attributes-type.cddl
 PROFILE_FRAGS += tee-cryptokey-type.cddl

--- a/cddl/raw-uint.cddl
+++ b/cddl/raw-uint.cddl
@@ -1,0 +1,6 @@
+$$measurement-values-map-extension //= (
+  &(raw-uint: -1) => raw-uint-type-choice
+)
+raw-uint-type-choice = uint / tagged-uint-range
+uint-range = [min: uint / positive-inf, max: uint / positive-inf]
+tagged-uint-range = #6.60011(uint-range) 

--- a/cddl/rfc9581.cddlx
+++ b/cddl/rfc9581.cddlx
@@ -1,0 +1,3 @@
+start = Etime
+
+;# import rfc9581

--- a/cddl/tee-attributes-type.cddl
+++ b/cddl/tee-attributes-type.cddl
@@ -1,5 +1,4 @@
 $$measurement-values-map-extension //= (
   &(tee.attributes: -82) => $tee-attributes-type
 )
-$tee-attributes-type /= mask-type
-$tee-attributes-type /= tagged-exp-mask-eq
+$tee-attributes-type /= $masked-value-type

--- a/cddl/tee-epoch-type.cddl
+++ b/cddl/tee-epoch-type.cddl
@@ -1,7 +1,0 @@
-$$measurement-values-map-extension //= (
-  &(tee.epoch: -90) => $tee-epoch-type
-)
-
-$tee-epoch-type /= $epoch-timestamp-type ; Intel profile - ~time / ~tdate
-$tee-epoch-type /= epoch-marker ; draft-ietf-rats-epoch-markers
-$tee-epoch-type /= etime ; RFC9581

--- a/cddl/tee-miscselect-type.cddl
+++ b/cddl/tee-miscselect-type.cddl
@@ -1,5 +1,4 @@
 $$measurement-values-map-extension //= (
   &(tee.miscselect: -81) => $tee-miscselect-type
 )
-$tee-miscselect-type /= mask-type
-$tee-miscselect-type /= tagged-exp-mask-eq
+$tee-miscselect-type /= $masked-value-type

--- a/cddl/tee-tcb-eval-num-type.cddl
+++ b/cddl/tee-tcb-eval-num-type.cddl
@@ -3,3 +3,4 @@ $$measurement-values-map-extension //= (
 )
 $tee-tcb-eval-num-type /= uint .within numeric-type
 $tee-tcb-eval-num-type /= tagged-numeric-ge
+$tee-tcb-eval-num-type /= tagged-uint-range

--- a/draft-cds-rats-intel-corim-profile.md
+++ b/draft-cds-rats-intel-corim-profile.md
@@ -327,7 +327,33 @@ The Intel Profile extends `measurement-values-map` which is used by Evidence, Re
 
 Reference Values extensions define types that can have multiple Reference Values that "match" a singleton Evidence value called "non-exact match" matching.
 Reference state expressions define non-exact-match matching semantics in terms of numeric ranges, date-time ranges, sets, and masks.
-Reference Values data types are identified by the CBOR tag `#6.60010(...)`.
+
+## Data Types {#sec-data-types}
+
+### Mask Type {#sec-mask}
+
+Reference Values expressed as an array of bits or bytes that uses a mask can indicate to a Verifier which
+bits or bytes of Evidence to ignore.
+
+Reference Value and mask arrays MUST be the same length for the mask to be applied correctly.
+Normally, Evidence would not supply a mask, while Endorsed Values would.
+The `tagged-masked-raw-value` indicates that an Evidence value of type `mask-type` is compared with
+a Reference Value of type `mask-type`, and that a mask of type `mask-type` is applied to both
+values before comparing values.
+
+The Verifier MUST ensure the lengths of values and mask are equivalent. If the mask is shorter
+than the values, the mask is padded with zeros (0) until it is the same length as the largest value.
+If the value length is shorter than the mask length, the value is padded with
+zeros (0) to the length of the mask.
+
+The mask data type definitions are as follows:
+
+~~~ cddl
+{::include cddl/mask-type.cddl}
+~~~
+
+If the Evidence bit field is a different length from the Reference Value and mask,
+the shorter length bit field is padded with zeros to accommodate the larger bit field.
 
 ## Expressions {#sec-expressions}
 
@@ -519,49 +545,6 @@ The set of sets expression definitions are as follows:
 {::include cddl/set-of-set-expr.cddl}
 ~~~
 
-### Mask Expression {#sec-mask-expression}
-
-Reference Values expressed as an array of bits or bytes that uses a mask can indicate to a Verifier which
-bits or bytes of Evidence to ignore.
-
-Reference Value and mask arrays MUST be the same length for the mask to be applied correctly.
-Normally, Evidence would not supply a mask, while Endorsed Values would.
-The `mask-eq` operator indicates that an Evidence value of type `mask-type` is compared with
-a Reference Value of type `mask-type`, and that a mask of type `mask-type` is applied to both
-values before comparing values. If the operator is `mask-eq`, then a binary equivalence comparison is applied.
-
-The Verifier MUST ensure the lengths of values and mask are equivalent. If the mask is shorter
-than the values, the mask is padded with zeros (0) until it is the same length as the largest value.
-If the Evidence or Reference Value length is shorter than the mask, the value is padded with
-zeros (0) to the length of the mask.
-
-The masked data type definitions are as follows:
-
-~~~ cddl
-{::include cddl/mask-type.cddl}
-~~~
-
-If the Evidence bit field is a different length from the Reference Value and mask,
-the shorter length bit field is padded with zeros to accommodate the larger bit field.
-
-The `tagged-exp-mask-eq` expression defines a tagged expression that applies the mask equivalence  operator to an Evidence value and a Reference Value using the supplied mask.
-
-In *infix* notation, the Evidence value is *operand_1*, followed by the mask operator, followed by a
-Reference Value, *operand_2*, followed by the mask, *operand_3*.
-
-Example:
-
-* <`evidence_value`> <`mask-eq`> <`reference_value`> <`mask`>
-
-If each bit in Evidence has a corresponding matching bit in the Reference Value, then the Evidence
-value is accepted.
-
-The masked data expression definitions are as follows:
-
-~~~ cddl
-{::include cddl/mask-expr.cddl}
-~~~
-
 ##  Measurement Extensions {#sec-measurement-extensions}
 
 This profile extends the CoMID `measurement-values-map` with additional code point definitions,
@@ -721,7 +704,7 @@ and the RVP to assert a Reference Value and mask.
 The `$tee-miscselect-type` is a 4 byte value and mask.
 
 The `$tee-miscselect-type` is a singleton `mask-type` value when used as Endorsement or Evidence
-and a `tagged-mask-expression` when used a Reference Value.
+and a `tagged-masked-raw-value` when used a Reference Value.
 
 ~~~ cddl
 {::include cddl/tee-miscselect-type.cddl}
@@ -923,7 +906,6 @@ IANA is requested to allocate the following tags in the CBOR Tags registry {{!IA
 |   60010 | `tag`               | Numeric Expressions, see {{sec-numeric-expressions}}          | {{&SELF}} |
 |   60020 | `tag`               | Set digest Expressions, see  {{sec-set-expressions}}          | {{&SELF}} |
 |   60021 | `tag`               | Set tstr Expressions, see  {{sec-set-expressions}}            | {{&SELF}} |
-|   60040 | `tag`               | Mask Expressions, see {{sec-mask-expression}}                 | {{&SELF}} |
 
 {: #tbl-iana-intel-profile-reg-items title="Intel Profile Tag Registration Code Points"}
 


### PR DESCRIPTION
Defines tagged-uint-range patterned after tagged-int-range in corim. It's used in use cases where a numeric expression that evaluates greater-than-or-equal such as tcb-eval-num.