### PR TITLE
Added 32-byte piid example

### DIFF
--- a/cddl/examples/irim-qe-ref.diag
+++ b/cddl/examples/irim-qe-ref.diag
@@ -50,8 +50,8 @@
               / mval / 1 : { 4 : 560(h'00') } / *** 1 byte *** /
             },
             / measurement-map / {  
-              / mkey / 0 : 101, / platform-instance-id /
-              / mval / 1 : { 4 : 560(h'000102030405060708090A0B0C0D0E0F') } / *** 16 bytes *** /
+              / mkey / 0 : 101, / platform-instance-id as variable length raw-value /
+              / mval / 1 : { 4 : 560(h'000102030405060708090A0B0C0D0E0F00000000000000000000000000000000') } / *** 32 bytes *** /
             }
           ]
         ]

--- a/draft-cds-rats-intel-corim-profile.md
+++ b/draft-cds-rats-intel-corim-profile.md
@@ -670,7 +670,7 @@ The `$tee-platform-instance-id-type` is a `bstr`.
 {::include cddl/tee-platform-instance-id-type.cddl}
 ~~~
 
-Alternatively, the platform instance ID may be encoded using `mkey` where `mkey` contains the non-negative `tee.platform-instance-id` and `mval`.`raw-value` contains the `$tee-platform-instance-id-type` value.
+Alternatively, the platform instance ID may be encoded using `mkey` where `mkey` contains the non-negative `tee.platform-instance-id` code point and `mval`.`raw-value` contains the `$tee-platform-instance-id-type` value.
 
 ### The tee.isvprodid Measurement Extension {#sec-tee-isvprodid-type}
 


### PR DESCRIPTION
Clarified explanitory text in markdown and updated mkey example to show variable length platform instance identifier.